### PR TITLE
[README] Fix broken link to `ARTiledImageView` tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A complete project can be found in [FBSnapshotTestCaseDemo](FBSnapshotTestCaseDe
 
 Notably, take a look at [FBSnapshotTestCaseDemoSpecs.m](FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseDemoSpecs.m) for a complete example, which is an expanded Specta version version of [FBSnapshotTestCaseDemoTests.m](https://github.com/facebook/ios-snapshot-test-case/blob/master/FBSnapshotTestCaseDemo/FBSnapshotTestCaseDemoTests/FBSnapshotTestCaseDemoTests.m).
 
-Finally you can consult the tests for [ARTiledImageView](https://github.com/dblock/ARTiledImageView/tree/master/Demo/DemoTests) or [NAMapKit](https://github.com/neilang/NAMapKit/tree/master/Demo/DemoTests).
+Finally you can consult the tests for [ARTiledImageView](https://github.com/dblock/ARTiledImageView/tree/master/IntegrationTests) or [NAMapKit](https://github.com/neilang/NAMapKit/tree/master/Demo/DemoTests).
 
 ### License
 


### PR DESCRIPTION
The location of the tests in `ARTiledImageView` has changed, so this updates the link to point its new location.
