### PR TITLE
Fix build for snapshot test case v1.6, and fix dependency podpsec versions

### DIFF
--- a/EXPMatchers+FBSnapshotTest.m
+++ b/EXPMatchers+FBSnapshotTest.m
@@ -30,7 +30,6 @@
 
 {
     FBSnapshotTestController *snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[testCase class]];
-    snapshotController.renderAsLayer = YES;
     snapshotController.recordMode = record;
     snapshotController.referenceImagesDirectory = referenceDirectory;
 

--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -11,5 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'EXPMatchers+FBSnapshotTest.{h,m}'
   s.frameworks   = 'Foundation', 'XCTest'
-  s.dependencies = ['Expecta', 'FBSnapshotTestCase']
+  s.dependency	 	 'FBSnapshotTestCase', '1.6'
+  s.dependency	 	 'Expecta', '0.3.2'
 end


### PR DESCRIPTION
Thanks for the lib!

`ios-snapshot-test-case` was just updated to 1.6 with the breaking change https://github.com/facebook/ios-snapshot-test-case/commit/6bebf152157e04eddcba231f21f35b7864a85db7. This broke `ios-snapshot-test-case-expecta` as well, so I removed the `renderAsLayer` setting. However, since the podspec leaves its dependency versions open, this was likely to happen. As such, I also fixed the dependency versions to avoid something like this happening in future.