### PR TITLE
Update FBSnapshotTestCase dependecy

### DIFF
--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'EXPMatchers+FBSnapshotTest.{h,m}'
   s.frameworks   = 'Foundation', 'XCTest'
-  s.dependency     'FBSnapshotTestCase', '1.6'
+  s.dependency     'FBSnapshotTestCase', '~> 1.8'
   s.dependency     'Expecta', '~> 1.0'
 end


### PR DESCRIPTION
Hi there,

The main `FBSnapshotTestCase` dependency is starting to get a little behind. Perhaps time to update? A reasonably quick inspection doesn't appear to throw any obvious big issues...

Thanks!