### PR TITLE
Bump FBSnapshot to 2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-### 1.x (Next)
+### 2.x (Next)
 
 * Your contribution here.
+
+### 2.0.0 (08/03/2015)
+
+* [#32](https://github.com/dblock/ios-snapshot-test-case-expecta/issues/32): Bump FBSnapshotTestCase to 2.0.3
 
 ### 1.3.4 (05/16/2015)
 

--- a/EXPMatchers+FBSnapshotTest.h
+++ b/EXPMatchers+FBSnapshotTest.h
@@ -7,6 +7,7 @@
 //
 
 #import <Expecta/Expecta.h>
+#import "ExpectaObject+FBSnapshotTest.h"
 
 @interface EXPExpectFBSnapshotTest : NSObject
 @end

--- a/EXPMatchers+FBSnapshotTest.m
+++ b/EXPMatchers+FBSnapshotTest.m
@@ -40,6 +40,7 @@
     return [snapshotController compareSnapshotOfViewOrLayer:viewOrLayer
                                                    selector:NSSelectorFromString(snapshot)
                                                  identifier:nil
+                                                  tolerance:0
                                                       error:error];
 }
 

--- a/EXPMatchers+FBSnapshotTest.m
+++ b/EXPMatchers+FBSnapshotTest.m
@@ -32,6 +32,7 @@
     FBSnapshotTestController *snapshotController = [[FBSnapshotTestController alloc] initWithTestClass:[testCase class]];
     snapshotController.recordMode = record;
     snapshotController.referenceImagesDirectory = referenceDirectory;
+    snapshotController.usesDrawViewHierarchyInRect = [Expecta usesDrawViewHierarchyInRect];
 
     if (! snapshotController.referenceImagesDirectory) {
         [NSException raise:@"Missing value for referenceImagesDirectory" format:@"Call [[EXPExpectFBSnapshotTest instance] setReferenceImagesDirectory"];

--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Expecta+Snapshots'
-  s.version      = '1.3.4'
+  s.version      = '2.0.0'
   s.summary      = 'Expecta matchers for taking view snapshots with FBSnapshotTestCase.'
   s.description  = "Use ios-snapshot-test-case's FBSnapshotTest with Expecta matchers for readability."
   s.homepage     = 'https://github.com/dblock/ios-snapshot-test-case-expecta'
@@ -11,6 +11,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'EXPMatchers+FBSnapshotTest.{h,m}'
   s.frameworks   = 'Foundation', 'XCTest'
-  s.dependency     'FBSnapshotTestCase', '~> 1.8'
+  s.dependency     'FBSnapshotTestCase/Core', '~> 2.0.3'
   s.dependency     'Expecta', '~> 1.0'
 end

--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/dblock/ios-snapshot-test-case-expecta.git', :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.source_files = 'EXPMatchers+FBSnapshotTest.{h,m}'
+  s.source_files = '*.{h,m}'
   s.frameworks   = 'Foundation', 'XCTest'
   s.dependency     'FBSnapshotTestCase/Core', '~> 2.0.3'
   s.dependency     'Expecta', '~> 1.0'

--- a/ExpectaObject+FBSnapshotTest.h
+++ b/ExpectaObject+FBSnapshotTest.h
@@ -1,0 +1,17 @@
+//
+//  ExpectaObject+FBSnapshotTest.h
+//  Expecta+Snapshots
+//
+//  Created by John Boiles on 8/3/15.
+//  Copyright (c) 2015 Expecta+Snapshots All rights reserved.
+//
+
+#import <Expecta/ExpectaObject.h>
+
+@interface Expecta (FBSnapshotTest)
+
++ (void)setUsesDrawViewHierarchyInRect:(BOOL)usesDrawViewHierarchyInRect;
+
++ (BOOL)usesDrawViewHierarchyInRect;
+
+@end

--- a/ExpectaObject+FBSnapshotTest.m
+++ b/ExpectaObject+FBSnapshotTest.m
@@ -1,0 +1,25 @@
+//
+//  ExpectaObject+FBSnapshotTest.m
+//  Expecta+Snapshots
+//
+//  Created by John Boiles on 8/3/15.
+//  Copyright (c) 2015 Expecta+Snapshots All rights reserved.
+//
+
+#import "ExpectaObject+FBSnapshotTest.h"
+#import <objc/runtime.h>
+
+static NSString const *kUsesDrawViewHierarchyInRectKey = @"ExpectaObject+FBSnapshotTest.usesDrawViewHierarchyInRect";
+
+@implementation Expecta (FBSnapshotTest)
+
++ (void)setUsesDrawViewHierarchyInRect:(BOOL)usesDrawViewHierarchyInRect {
+    objc_setAssociatedObject(self, (__bridge const void *)(kUsesDrawViewHierarchyInRectKey), @(usesDrawViewHierarchyInRect), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
++ (BOOL)usesDrawViewHierarchyInRect {
+    NSNumber *usesDrawViewHierarchyInRect = objc_getAssociatedObject(self, (__bridge const void *)(kUsesDrawViewHierarchyInRectKey));
+    return usesDrawViewHierarchyInRect.boolValue;
+}
+
+@end

--- a/FBSnapshotTestCaseDemo/Podfile
+++ b/FBSnapshotTestCaseDemo/Podfile
@@ -4,7 +4,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.0'
 
 target 'FBSnapshotTestCaseDemoTests', :exclusive => true do
-  pod 'FBSnapshotTestCase'
   pod 'Specta'
   pod 'Expecta+Snapshots', :path => "../"
 end

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Use `expect(view).to.recordSnapshotNamed(@"unique snapshot name")` to record a s
 
 If you project was compiled with Specta included, you have two extra methods that use the spec hierarchy to generate the snapshot name for you: `recordSnapshot()` and `haveValidSnapshot()`. You should only call these once per `it()` block.
 
+If you need the `usesDrawViewHierarchyInRect` property in order to correctly render UIVisualEffect, UIAppearance and Size Classes, call `[Expecta setUsesDrawViewHierarchyInRect:NO];` inside `beforeAll`.
+
 ``` Objective-C
 #define EXP_SHORTHAND
 #include <Specta/Specta.h>


### PR DESCRIPTION
From #32: Adds support for FBSnapshotTestCase 2.0.3.

In order to support the shiny new `usesDrawViewHierarchyInRect` property of `FBSnapshotTestCase`, I added a category on the `Expecta` object (from [ExpectaObject.h](https://github.com/specta/expecta/blob/c52e84681323ad42a47e6e96fd6debb577a26cc1/Expecta/ExpectaObject.h)) that has the method `setUsesDrawViewHierarchyInRect:`. This is similar to how Expecta handles setting timeouts for asynchronous tests, so I think it's reasonably Expecta-like.

In retrospect, it might have been simpler to do the same thing as `setGlobalReferenceImageDir` and just create a global function for setting this property. I'm open to making that change if you think it'd be better. Or I can move `setGlobalReferenceImageDir:` into `Expecta+FBSnapshotTest`. I'll leave it up to you.