### PR TITLE
Disable bitcode when installed through Cocoapods

### DIFF
--- a/Expecta+Snapshots.podspec
+++ b/Expecta+Snapshots.podspec
@@ -14,4 +14,6 @@ Pod::Spec.new do |s|
   s.dependency     'FBSnapshotTestCase/Core', '~> 2.0'
   s.dependency     'Expecta', '~> 1.0'
   s.dependency     'Specta', '~> 1.0'
+  
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
Default setting `Enable Bitcode = YES` prevents from testing on device:

```
'XCTest' does not contain bitcode
```

Specta and Expecta added this setting as well: [specta/#179](https://github.com/specta/specta/pull/179), [expecta/#179](https://github.com/specta/expecta/pull/179).
Funny, just noticed - the same PR# for both projects :)