### PR TITLE
Add missing import of CoreGraphics framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ### 3.x (Next)
 
+* [#46](https://github.com/dblock/ios-snapshot-test-case-expecta/pull/46): Add missing import of CoreGraphics framework - [@leoformaggio](https://github.com/leoformaggio).
+
 ### 3.3.0 (02/21/2017)
 
 * [#45](https://github.com/dblock/ios-snapshot-test-case-expecta/pull/45): Add support for image approximation - [@leoformaggio](https://github.com/leoformaggio).

--- a/EXPMatchers+FBSnapshotTest.h
+++ b/EXPMatchers+FBSnapshotTest.h
@@ -1,3 +1,4 @@
+#import <CoreGraphics/CoreGraphics.h>
 #import <Expecta/Expecta.h>
 #import "ExpectaObject+FBSnapshotTest.h"
 


### PR DESCRIPTION
Some projects, for example those which doesn't have a `.pch` file importing either `UIKit` or `CoreGraphics`, won't compile without this. Sorry my fault on the previous PR guys 😬 