### PR TITLE
docs: doc updates for new ci + test commands #trivial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,12 @@ Install dependencies via CocoaPods for the demo project.
 
 ```
 cd FBSnapshotTestCaseDemo
-pod install
+bundle exec pod install
 ```
 
 #### Open Workspace
 
-Open the ios-snapshot-test-case-expecta.xcworkspace workspace in XCode.
+Open the ios-snapshot-test-case-expecta.xcworkspace workspace in Xcode.
 
 #### Write Tests
 
@@ -55,7 +55,9 @@ Implement your feature or bug fix.
 Make sure that you can build the project and run all tests successfully.
 
 ```
-make all
+cd FBSnapshotTestCaseDemo
+bundle exec pod install
+xcodebuild -workspace FBSnapshotTestCaseDemo.xcworkspace -scheme FBSnapshotTestCaseDemo -sdk iphonesimulator -destination 'name=iPhone 15' build test | bundle exec xcpretty -c
 ```
 
 #### Write Documentation
@@ -119,7 +121,7 @@ git push origin my-feature-branch -f
 
 #### Check on Your Pull Request
 
-Go back to your pull request after a few minutes and see whether it passed muster with Travis-CI. Everything should look green, otherwise fix issues and amend your commit as described above.
+Go back to your pull request after a few minutes and see whether it passed muster with CI. Everything should look green, otherwise fix issues and amend your commit as described above.
 
 #### Be Patient
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,10 +10,10 @@ Run tests, check that all tests succeed locally.
 ```
 cd FBSnapshotTestCaseDemo
 bundle exec pod install
-xcodebuild -workspace FBSnapshotTestCaseDemo.xcworkspace -scheme FBSnapshotTestCaseDemo -sdk iphonesimulator -destination 'name=iPhone 6' build test | xcpretty -c
+xcodebuild -workspace FBSnapshotTestCaseDemo.xcworkspace -scheme FBSnapshotTestCaseDemo -sdk iphonesimulator -destination 'name=iPhone 15' build test | bundle exec xcpretty -c
 ```
 
-Check that the last build succeeded in [Travis CI](https://travis-ci.org/dblock/ios-snapshot-test-case-expecta).
+Check that the last build succeeded in [GitHub Actions](https://github.com/dblock/ios-snapshot-test-case-expecta/actions/workflows/build-and-test.yml).
 
 Increment the version, modify [Expecta+Snapshots.podspec](Expecta+Snapshots.podspec).
 
@@ -32,7 +32,7 @@ Remove the line with "Your contribution here.", since there will be no more cont
 Make sure the library is ready for release.
 
 ```
-pod lib lint
+bundle exec pod lib lint
 ```
 
 Commit your changes.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,7 +13,9 @@ bundle exec pod install
 xcodebuild -workspace FBSnapshotTestCaseDemo.xcworkspace -scheme FBSnapshotTestCaseDemo -sdk iphonesimulator -destination 'name=iPhone 15' build test | bundle exec xcpretty -c
 ```
 
-Check that the last build succeeded in [GitHub Actions](https://github.com/dblock/ios-snapshot-test-case-expecta/actions/workflows/build-and-test.yml).
+Check that the last build succeeded:
+
+[![Build and test](https://github.com/dblock/ios-snapshot-test-case-expecta/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/dblock/ios-snapshot-test-case-expecta/actions/workflows/build-and-test.yml)
 
 Increment the version, modify [Expecta+Snapshots.podspec](Expecta+Snapshots.podspec).
 


### PR DESCRIPTION
Minor updates to release and contributing docs to remove references to travis ci and update any outdated commands. 
Didn't add a changelog since it doesn't touch code but let me know if you want one. 